### PR TITLE
docker compose が動かない問題

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,11 +6,11 @@ WORKDIR /app
 
 RUN pip install poetry
 
-COPY pyproject.toml* poetry.lock* ./
+COPY backend/pyproject.toml backend/poetry.lock ./
 
 ENV PYTHONPATH=/app/api
 
-RUN poetry config virtualenvs.in-project true
-RUN if [ -f pyproject.toml ]; then poetry install --no-root; fi
+RUN poetry export -f requirements.txt --output requirements.txt
+RUN pip install -r requirements.txt
 
-ENTRYPOINT ["poetry", "run", "uvicorn", "main:app", "--host", "0.0.0.0","--port", "8000", "--reload"]
+ENTRYPOINT ["poetry", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       dockerfile: ./backend/Dockerfile
       context: .
     volumes:
-      - ./backend/dockervenv:/src/.venv
       - type: bind
         source: ./backend
         target: /app


### PR DESCRIPTION
## Introduction

- local で build した時には docker-compose は動くが、CI では動かない。
- まず、docker-compose では、local のファイルで venv を上書きしていた。
  - compose 側の path を渡している箇所を削除 
- それと 実際は build できていなかったんじゃないか疑惑。
  -  poetry 周りのファイルの渡し方が悪かった
  - ファイルがあった場合のみ build するのはおかしいので、なかったら落とす
    - 間違いを中途半端にスルーされると何が正しいのかわからなくなります
- 最後に、docker では poetry の venv を読み込めているが、docker compose では venv を読み込めていない。
  - poetry を使ったことはないので、周りの人たちがどうしているのかは知らない。
  - が、pipenv なら仮想環境ではなく、そのまま system に install する慣わしとなっている。
  - それに倣った。
  - ちなみにこの方針が正しいかどうかは確認しておくべき

## Tickets

- Nothing

## Related Pull Requests

- Nothing

## Changing Points

- backend/Dockerfile
  - COPY 時のPATH 指定方法を変更
  - poetry からライブラリの依存を掻き出し、それを pip で読み込む
- docker-compse.yml
  -  venv に bind している箇所を止める。